### PR TITLE
fix(#88): remap 2fa verifications on user email change

### DIFF
--- a/projects/lib-service-test-utils/src/create-test-user.test.ts
+++ b/projects/lib-service-test-utils/src/create-test-user.test.ts
@@ -7,7 +7,7 @@ test('it creates a test user with the expected data', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   expect(user).toStrictEqual({
     createdAt: expect.any(Date),
@@ -27,7 +27,7 @@ test('it creates a passwordless user when password is null', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db, user: { password: null } });
+  const user = await createTestUser(db, { password: null });
 
   expect(user.passwordHash).toBeNull();
 });
@@ -37,13 +37,10 @@ test('it allows overriding the default user data', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({
-    db,
-    user: {
-      email: 'test@test.com',
-      name: 'Test User',
-      username: 'test_user',
-    },
+  const user = await createTestUser(db, {
+    email: 'test@test.com',
+    name: 'Test User',
+    username: 'test_user',
   });
 
   expect(user.email).toBe('test@test.com');

--- a/projects/lib-service-test-utils/src/create-test-user.ts
+++ b/projects/lib-service-test-utils/src/create-test-user.ts
@@ -2,24 +2,22 @@ import * as schema from '@vers/postgres-schema';
 import { hashPassword } from '@vers/service-utils';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
-interface TestUserConfig {
-  db: PostgresJsDatabase<typeof schema>;
-  user?: Partial<Omit<typeof schema.users.$inferSelect, 'passwordHash'>> & {
+type TestUserData = Partial<
+  Omit<typeof schema.users.$inferSelect, 'passwordHash'> & {
     password?: null | string;
-  };
-}
+  }
+>;
 
 export async function createTestUser(
-  config: TestUserConfig,
+  db: PostgresJsDatabase<typeof schema>,
+  data: TestUserData = {},
 ): Promise<typeof schema.users.$inferSelect> {
   const now = new Date();
 
-  const { password, ...rest } = config.user ?? {};
-
   let passwordHash = null;
 
-  if (password !== null) {
-    passwordHash = await hashPassword(password ?? 'password123');
+  if (data.password !== null) {
+    passwordHash = await hashPassword(data.password ?? 'password123');
   }
 
   const user = {
@@ -32,10 +30,10 @@ export async function createTestUser(
     passwordResetTokenExpiresAt: null,
     updatedAt: now,
     username: 'test_user',
-    ...rest,
-  };
+    ...data,
+  } satisfies typeof schema.users.$inferInsert;
 
-  await config.db.insert(schema.users).values(user);
+  await db.insert(schema.users).values(user);
 
   return user;
 }

--- a/projects/lib-service-test-utils/src/create-test-verification.test.ts
+++ b/projects/lib-service-test-utils/src/create-test-verification.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest';
+import { createTestDB } from './create-test-db';
+import { createTestVerification } from './create-test-verification';
+
+test('it creates a test verification with the expected data', async () => {
+  await using handle = await createTestDB();
+
+  const { db } = handle;
+
+  const verification = await createTestVerification(db);
+
+  expect(verification).toStrictEqual({
+    algorithm: 'SHA-256',
+    charSet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+    createdAt: expect.any(Date),
+    digits: 6,
+    expiresAt: null,
+    id: expect.any(String),
+    period: 30,
+    secret: expect.any(String),
+    target: 'test@example.com',
+    type: '2fa',
+  });
+});
+
+test('it allows overriding the default verification data', async () => {
+  await using handle = await createTestDB();
+
+  const { db } = handle;
+
+  const verification = await createTestVerification(db, {
+    target: 'test@test.com',
+    type: '2fa',
+  });
+
+  expect(verification.target).toBe('test@test.com');
+  expect(verification.type).toBe('2fa');
+});

--- a/projects/lib-service-test-utils/src/create-test-verification.ts
+++ b/projects/lib-service-test-utils/src/create-test-verification.ts
@@ -1,0 +1,32 @@
+import { generateTOTP } from '@epic-web/totp';
+import { createId } from '@paralleldrive/cuid2';
+import * as schema from '@vers/postgres-schema';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+type TestVerificationData = Partial<typeof schema.verifications.$inferSelect>;
+
+export async function createTestVerification(
+  db: PostgresJsDatabase<typeof schema>,
+  data: TestVerificationData = {},
+): Promise<typeof schema.verifications.$inferSelect> {
+  const now = new Date();
+
+  const { otp, ...verificationConfig } = await generateTOTP({
+    algorithm: 'SHA-256',
+    charSet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+  });
+
+  const verification = {
+    createdAt: now,
+    expiresAt: null,
+    id: createId(),
+    target: 'test@example.com',
+    type: '2fa',
+    ...verificationConfig,
+    ...data,
+  } satisfies typeof schema.verifications.$inferInsert;
+
+  await db.insert(schema.verifications).values(verification);
+
+  return verification;
+}

--- a/projects/lib-service-test-utils/src/index.ts
+++ b/projects/lib-service-test-utils/src/index.ts
@@ -2,5 +2,6 @@ export { createPostgresContainer } from './create-postgres-container';
 export { createTestDB } from './create-test-db';
 export { createTestJWT } from './create-test-jwt';
 export { createTestUser } from './create-test-user';
+export { createTestVerification } from './create-test-verification';
 export { getContainerConnectionURI } from './get-container-connection-uri';
 export { setupTestDB } from './setup-test-db';

--- a/projects/lib-service-types/src/service-email.ts
+++ b/projects/lib-service-types/src/service-email.ts
@@ -1,8 +1,1 @@
-export interface SendEmailArgs {
-  html: string;
-  plainText: string;
-  subject: string;
-  to: string;
-}
-
 export type SendEmailPayload = Record<string, never>;

--- a/projects/lib-service-types/src/service-session.ts
+++ b/projects/lib-service-types/src/service-session.ts
@@ -16,36 +16,12 @@ export type AuthPayload = SessionTokens & {
   session: SessionData;
 };
 
-export interface CreateSessionArgs {
-  expiresAt?: Date;
-  ipAddress: string;
-  rememberMe?: boolean;
-  userID: string;
-}
-
 export type CreateSessionPayload = AuthPayload;
-
-export interface DeleteSessionArgs {
-  id: string;
-  userID: string;
-}
 
 export type DeleteSessionPayload = Record<string, never>;
 
-export interface GetSessionArgs {
-  id: string;
-}
-
 export type GetSessionPayload = null | SessionData;
 
-export interface GetSessionsArgs {
-  userID: string;
-}
-
 export type GetSessionsPayload = Array<SessionData>;
-
-export interface RefreshTokensArgs {
-  refreshToken: string;
-}
 
 export type RefreshTokensPayload = AuthPayload;

--- a/projects/lib-service-types/src/service-user.ts
+++ b/projects/lib-service-types/src/service-user.ts
@@ -7,63 +7,28 @@ export interface UserData {
   username: string;
 }
 
-export interface CreateUserArgs {
-  email: string;
-  name: string;
-  password: string;
-  username: string;
-}
-
 export type CreateUserPayload = UserData;
 
-export interface GetUserArgs {
-  email?: string;
-  id?: string;
-}
-
 export type GetUserPayload = null | UserData;
-
-export interface VerifyPasswordArgs {
-  email: string;
-  password: string;
-}
 
 export interface VerifyPasswordPayload {
   success: boolean;
 }
 
-export interface ResetPasswordArgs {
-  id: string;
-  password: string;
-  resetToken: string;
-}
-
 export type ResetPasswordPayload = Record<string, never>;
-
-export interface ChangePasswordArgs {
-  password: string;
-  userID: string;
-}
 
 export interface ChangePasswordPayload {
   updatedID: string;
-}
-
-export interface CreatePasswordResetTokenArgs {
-  id: string;
 }
 
 export interface CreatePasswordResetTokenPayload {
   resetToken: string;
 }
 
-export interface UpdateUserArgs {
-  email?: string;
-  id: string;
-  name?: string;
-  username?: string;
+export interface UpdateUserPayload {
+  updatedID: string;
 }
 
-export interface UpdateUserPayload {
+export interface UpdateEmailPayload {
   updatedID: string;
 }

--- a/projects/lib-service-types/src/service-verification.ts
+++ b/projects/lib-service-types/src/service-verification.ts
@@ -9,49 +9,18 @@ interface VerificationData {
   type: VerificationType;
 }
 
-export interface CreateVerificationArgs {
-  expiresAt?: Date | null;
-  period?: number;
-  target: string;
-  type: VerificationType;
-}
-
 export type CreateVerificationPayload = VerificationData & { otp: string };
-
-export interface VerifyCodeArgs {
-  code: string;
-  target: string;
-  type: VerificationType;
-}
 
 export type VerifyCodePayload = null | VerificationData;
 
-export interface GetVerificationArgs {
-  target: string;
-  type: VerificationType;
-}
-
 export type GetVerificationPayload = null | VerificationData;
-
-export interface UpdateVerificationArgs {
-  id: string;
-  type?: VerificationType;
-}
 
 export interface UpdateVerificationPayload {
   updatedID: string;
 }
 
-export interface DeleteVerificationArgs {
-  id: string;
-}
-
 export interface DeleteVerificationPayload {
   deletedID: string;
-}
-
-export interface Get2FAVerificationURIArgs {
-  target: string;
 }
 
 export interface Get2FAVerificationURIPayload {

--- a/projects/service-api/src/mocks/handlers/index.ts
+++ b/projects/service-api/src/mocks/handlers/index.ts
@@ -9,6 +9,7 @@ import { createPasswordResetToken } from './trpc/service-user/create-password-re
 import { createUser } from './trpc/service-user/create-user';
 import { getUser } from './trpc/service-user/get-user';
 import { resetPassword } from './trpc/service-user/reset-password';
+import { updateEmail } from './trpc/service-user/update-email';
 import { updateUser } from './trpc/service-user/update-user';
 import { verifyPassword } from './trpc/service-user/verify-password';
 import { createVerification } from './trpc/service-verification/create-verification';
@@ -37,6 +38,7 @@ export const handlers = [
   getUser,
   verifyPassword,
   updateUser,
+  updateEmail,
 
   // service-verification
   createVerification,

--- a/projects/service-api/src/mocks/handlers/trpc/service-email/send-email.ts
+++ b/projects/service-api/src/mocks/handlers/trpc/service-email/send-email.ts
@@ -1,13 +1,23 @@
 import { vi } from 'vitest';
-import { SendEmailArgs } from '@vers/service-types';
 import { trpc } from './trpc';
 
-export const sentEmails = new Map<string, Array<SendEmailArgs>>();
+interface SendEmailInput {
+  html: string;
+  plainText: string;
+  subject: string;
+  to: string;
+}
 
-export const sendEmailHandler = vi.fn(({ input }: { input: SendEmailArgs }) => {
-  const emails = sentEmails.get(input.to) ?? [];
+interface SendEmailProcedureArgs {
+  input: SendEmailInput;
+}
 
-  sentEmails.set(input.to, [...emails, input]);
+export const sentEmails = new Map<string, Array<SendEmailInput>>();
+
+export const sendEmailHandler = vi.fn((args: SendEmailProcedureArgs) => {
+  const emails = sentEmails.get(args.input.to) ?? [];
+
+  sentEmails.set(args.input.to, [...emails, args.input]);
 
   return {};
 });

--- a/projects/service-api/src/mocks/handlers/trpc/service-user/change-password.ts
+++ b/projects/service-api/src/mocks/handlers/trpc/service-user/change-password.ts
@@ -7,7 +7,7 @@ export const changeUserPassword = trpc.changePassword.mutation(({ input }) => {
   try {
     const user = db.user.findFirst({
       where: {
-        id: { equals: input.userID },
+        id: { equals: input.id },
       },
     });
 

--- a/projects/service-api/src/mocks/handlers/trpc/service-user/update-email.ts
+++ b/projects/service-api/src/mocks/handlers/trpc/service-user/update-email.ts
@@ -1,0 +1,49 @@
+import type { UpdateUserPayload } from '@vers/service-types';
+import { TRPCError } from '@trpc/server';
+import { db } from '../../../db';
+import { trpc } from './trpc';
+
+export const updateEmail = trpc.updateEmail.mutation(({ input }) => {
+  const user = db.user.findFirst({
+    where: { id: { equals: input.id } },
+  });
+
+  if (!user) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'User not found',
+    });
+  }
+
+  const twoFactorVerification = db.verification.findFirst({
+    where: {
+      target: { equals: input.email },
+      type: { in: ['2fa', '2fa-setup'] },
+    },
+  });
+
+  const updatedUser = db.user.update({
+    data: { email: input.email },
+    where: { id: { equals: input.id } },
+  });
+
+  if (!updatedUser) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to update user',
+    });
+  }
+
+  if (twoFactorVerification) {
+    db.verification.update({
+      data: { target: input.email },
+      where: { id: { equals: twoFactorVerification.id } },
+    });
+  }
+
+  const result: UpdateUserPayload = {
+    updatedID: updatedUser.id,
+  };
+
+  return result;
+});

--- a/projects/service-api/src/schema/mutations/change-user-password.ts
+++ b/projects/service-api/src/schema/mutations/change-user-password.ts
@@ -81,8 +81,8 @@ export async function changeUserPassword(
     }
 
     await ctx.services.user.changePassword.mutate({
+      id: ctx.user.id,
       password: args.input.newPassword,
-      userID: ctx.user.id,
     });
 
     const email = await generatePasswordChangedEmail({

--- a/projects/service-api/src/schema/mutations/finish-change-user-email.ts
+++ b/projects/service-api/src/schema/mutations/finish-change-user-email.ts
@@ -57,7 +57,7 @@ export async function finishChangeUserEmail(
 
     const prevEmail = ctx.user.email;
 
-    await ctx.services.user.updateUser.mutate({
+    await ctx.services.user.updateEmail.mutate({
       email: args.input.email,
       id: ctx.user.id,
     });

--- a/projects/service-api/src/schema/mutations/verify-otp.test.ts
+++ b/projects/service-api/src/schema/mutations/verify-otp.test.ts
@@ -261,12 +261,15 @@ test('it verifies a valid reset password otp and returns a valid transaction tok
 });
 
 test('it verifies a valid change email confirmation otp and returns a valid transaction token', async () => {
-  const ctx = createMockGQLContext({});
+  const user = db.user.create();
+  const session = db.session.create({ userID: user.id });
+
+  const ctx = createMockGQLContext({ session });
 
   const transactionID = createPendingTransaction({
     action: VerificationType.CHANGE_EMAIL_CONFIRMATION,
     ipAddress: ctx.ipAddress,
-    sessionID: null,
+    sessionID: session.id,
     target: 'test@example.com',
   });
 
@@ -284,6 +287,7 @@ test('it verifies a valid change email confirmation otp and returns a valid tran
   const args = {
     input: {
       code: otp,
+      sessionID: session.id,
       target: 'test@example.com',
       transactionID,
       type: VerificationType.CHANGE_EMAIL_CONFIRMATION,
@@ -314,7 +318,7 @@ test('it verifies a valid change email confirmation otp and returns a valid tran
     ip_address: ctx.ipAddress,
     jti: expect.any(String),
     mfa_verified: true,
-    session_id: null,
+    session_id: session.id,
     sub: 'test@example.com',
     transaction_id: transactionID,
   });

--- a/projects/service-api/src/utils/verify-transaction-token.ts
+++ b/projects/service-api/src/utils/verify-transaction-token.ts
@@ -20,9 +20,11 @@ const JWTPayloadSchema = z.object({
 
 const SESSION_REQUIRED_ACTIONS = new Set([
   VerificationType.CHANGE_EMAIL,
+  VerificationType.CHANGE_EMAIL_CONFIRMATION,
   VerificationType.CHANGE_PASSWORD,
   VerificationType.TWO_FACTOR_AUTH,
   VerificationType.TWO_FACTOR_AUTH_DISABLE,
+  VerificationType.TWO_FACTOR_AUTH_SETUP,
 ]);
 
 interface VerifyTransactionTokenData {

--- a/projects/service-session/src/handlers/create-session.test.ts
+++ b/projects/service-session/src/handlers/create-session.test.ts
@@ -17,7 +17,7 @@ interface TestConfig {
 async function setupTest(config: TestConfig) {
   const caller = createCaller({ db: config.db });
 
-  const user = await createTestUser({ db: config.db });
+  const user = await createTestUser(config.db);
 
   return { caller, user };
 }

--- a/projects/service-session/src/handlers/delete-session.test.ts
+++ b/projects/service-session/src/handlers/delete-session.test.ts
@@ -14,7 +14,7 @@ interface TestConfig {
 async function setupTest(config: TestConfig) {
   const caller = createCaller({ db: config.db });
 
-  const user = await createTestUser({ db: config.db });
+  const user = await createTestUser(config.db);
 
   return { caller, user };
 }

--- a/projects/service-session/src/handlers/get-session.test.ts
+++ b/projects/service-session/src/handlers/get-session.test.ts
@@ -15,7 +15,7 @@ interface TestConfig {
 async function setupTest(config: TestConfig) {
   const caller = createCaller({ db: config.db });
 
-  const user = await createTestUser({ db: config.db });
+  const user = await createTestUser(config.db);
 
   return { caller, user };
 }

--- a/projects/service-session/src/handlers/get-sessions.test.ts
+++ b/projects/service-session/src/handlers/get-sessions.test.ts
@@ -15,7 +15,7 @@ interface TestConfig {
 async function setupTest(config: TestConfig) {
   const caller = createCaller({ db: config.db });
 
-  const user = await createTestUser({ db: config.db });
+  const user = await createTestUser(config.db);
 
   return { caller, user };
 }

--- a/projects/service-session/src/handlers/refresh-tokens.test.ts
+++ b/projects/service-session/src/handlers/refresh-tokens.test.ts
@@ -20,7 +20,7 @@ interface TestConfig {
 async function setupTest(config: TestConfig) {
   const caller = createCaller({ db: config.db });
 
-  const user = await createTestUser({ db: config.db });
+  const user = await createTestUser(config.db);
 
   return { caller, user };
 }

--- a/projects/service-user/src/handlers/change-password.test.ts
+++ b/projects/service-user/src/handlers/change-password.test.ts
@@ -23,12 +23,13 @@ test('it changes the user password', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
+
   const { caller } = setupTest({ db });
 
   const result = await caller.changePassword({
+    id: user.id,
     password: 'newpassword123',
-    userID: user.id,
   });
 
   expect(result).toStrictEqual({ updatedID: user.id });
@@ -49,8 +50,8 @@ test('it throws an error if the user does not exist', async () => {
 
   await expect(
     caller.changePassword({
+      id: 'non-existent-id',
       password: 'newpassword123',
-      userID: 'non-existent-id',
     }),
   ).rejects.toThrow('No user with that ID');
 });

--- a/projects/service-user/src/handlers/change-password.ts
+++ b/projects/service-user/src/handlers/change-password.ts
@@ -9,8 +9,8 @@ import type { Context } from '../types';
 import { t } from '../t';
 
 export const ChangePasswordInputSchema = z.object({
+  id: z.string(),
   password: z.string(),
-  userID: z.string(),
 });
 
 export async function changePassword(
@@ -18,10 +18,10 @@ export async function changePassword(
   ctx: Context,
 ): Promise<ChangePasswordPayload> {
   try {
-    const { password, userID } = input;
+    const { id, password } = input;
 
     const user = await ctx.db.query.users.findFirst({
-      where: eq(schema.users.id, userID),
+      where: eq(schema.users.id, id),
     });
 
     if (!user) {
@@ -39,7 +39,7 @@ export async function changePassword(
         passwordHash,
         updatedAt: new Date(),
       })
-      .where(eq(schema.users.id, userID))
+      .where(eq(schema.users.id, id))
       .returning({
         updatedID: schema.users.id,
       });

--- a/projects/service-user/src/handlers/create-password-reset-token.test.ts
+++ b/projects/service-user/src/handlers/create-password-reset-token.test.ts
@@ -23,7 +23,7 @@ test('it creates a password reset token for an existing user', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   const { caller } = setupTest({ db });
 
@@ -52,7 +52,7 @@ test('it updates the user record with the new reset token', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   const { caller } = setupTest({ db });
 
@@ -95,7 +95,7 @@ test('it throws an error if the user has no password', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db, user: { password: null } });
+  const user = await createTestUser(db, { password: null });
 
   const { caller } = setupTest({ db });
 

--- a/projects/service-user/src/handlers/get-user.test.ts
+++ b/projects/service-user/src/handlers/get-user.test.ts
@@ -22,7 +22,7 @@ test('it gets a user by ID', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   const { caller } = setupTest({ db });
 
@@ -38,7 +38,7 @@ test('it gets a user by email', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   const { caller } = setupTest({ db });
 

--- a/projects/service-user/src/handlers/reset-password.test.ts
+++ b/projects/service-user/src/handlers/reset-password.test.ts
@@ -24,12 +24,9 @@ test('it updates the password and clears the reset token for an existing user', 
 
   const { db } = handle;
 
-  const user = await createTestUser({
-    db,
-    user: {
-      passwordResetToken: 'test_reset_token',
-      passwordResetTokenExpiresAt: new Date(Date.now() + 1000 * 60 * 10),
-    },
+  const user = await createTestUser(db, {
+    passwordResetToken: 'test_reset_token',
+    passwordResetTokenExpiresAt: new Date(Date.now() + 1000 * 60 * 10),
   });
 
   const { caller } = setupTest({ db });
@@ -83,12 +80,9 @@ test('it throws an error if the reset token is invalid', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({
-    db,
-    user: {
-      passwordResetToken: 'test_reset_token',
-      passwordResetTokenExpiresAt: new Date(Date.now() + 1000 * 60 * 10),
-    },
+  const user = await createTestUser(db, {
+    passwordResetToken: 'test_reset_token',
+    passwordResetTokenExpiresAt: new Date(Date.now() + 1000 * 60 * 10),
   });
 
   const { caller } = setupTest({ db });
@@ -110,12 +104,9 @@ test('it throws an error if the reset token has expired', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({
-    db,
-    user: {
-      passwordResetToken: 'test_reset_token',
-      passwordResetTokenExpiresAt: new Date(Date.now() - 1000 * 60 * 10),
-    },
+  const user = await createTestUser(db, {
+    passwordResetToken: 'test_reset_token',
+    passwordResetTokenExpiresAt: new Date(Date.now() - 1000 * 60 * 10),
   });
 
   const { caller } = setupTest({ db });

--- a/projects/service-user/src/handlers/update-email.test.ts
+++ b/projects/service-user/src/handlers/update-email.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from 'vitest';
+import * as schema from '@vers/postgres-schema';
+import {
+  createTestDB,
+  createTestUser,
+  createTestVerification,
+} from '@vers/service-test-utils';
+import { eq } from 'drizzle-orm';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { router } from '../router';
+import { t } from '../t';
+
+const createCaller = t.createCallerFactory(router);
+
+interface TestConfig {
+  db: PostgresJsDatabase<typeof schema>;
+}
+
+function setupTest(config: TestConfig) {
+  const caller = createCaller({ db: config.db });
+
+  return { caller };
+}
+
+test('it updates the provided user email', async () => {
+  await using handle = await createTestDB();
+
+  const { db } = handle;
+
+  const user = await createTestUser(db);
+
+  const { caller } = setupTest({ db });
+
+  const update = {
+    email: 'updated@test.com',
+    id: user.id,
+  };
+
+  const result = await caller.updateEmail(update);
+
+  expect(result).toStrictEqual({ updatedID: user.id });
+
+  const updatedUser = await db.query.users.findFirst({
+    where: eq(schema.users.id, user.id),
+  });
+
+  expect(updatedUser).toStrictEqual({
+    ...user,
+    email: 'updated@test.com',
+    updatedAt: expect.any(Date),
+  });
+
+  expect(updatedUser?.updatedAt.getTime()).toBeGreaterThan(
+    user.updatedAt.getTime(),
+  );
+});
+
+test('it updates a users 2FA verification', async () => {
+  await using handle = await createTestDB();
+
+  const { db } = handle;
+
+  const user = await createTestUser(db, { email: 'test@test.com' });
+  const verification = await createTestVerification(db, {
+    target: user.email,
+    type: '2fa',
+  });
+
+  const { caller } = setupTest({ db });
+
+  const update = {
+    email: 'updated@test.com',
+    id: user.id,
+  };
+
+  await caller.updateEmail(update);
+
+  const updatedVerification = await db.query.verifications.findFirst({
+    where: eq(schema.verifications.id, verification.id),
+  });
+
+  expect(updatedVerification).toStrictEqual({
+    ...verification,
+    target: 'updated@test.com',
+  });
+});
+
+test('it updates a users 2FA setup verification', async () => {
+  await using handle = await createTestDB();
+
+  const { db } = handle;
+
+  const user = await createTestUser(db, { email: 'test@test.com' });
+  const verification = await createTestVerification(db, {
+    target: user.email,
+    type: '2fa-setup',
+  });
+
+  const { caller } = setupTest({ db });
+
+  const update = {
+    email: 'updated@test.com',
+    id: user.id,
+  };
+
+  await caller.updateEmail(update);
+
+  const updatedVerification = await db.query.verifications.findFirst({
+    where: eq(schema.verifications.id, verification.id),
+  });
+
+  expect(updatedVerification).toStrictEqual({
+    ...verification,
+    target: 'updated@test.com',
+  });
+});

--- a/projects/service-user/src/handlers/update-email.ts
+++ b/projects/service-user/src/handlers/update-email.ts
@@ -1,0 +1,79 @@
+import { TRPCError } from '@trpc/server';
+import * as schema from '@vers/postgres-schema';
+import { UpdateEmailPayload } from '@vers/service-types';
+import { and, eq, or } from 'drizzle-orm';
+import { z } from 'zod';
+import { logger } from '~/logger';
+import type { Context } from '../types';
+import { t } from '../t';
+
+export const UpdateEmailInputSchema = z.object({
+  email: z.string(),
+  id: z.string(),
+});
+
+export async function updateEmail(
+  input: z.infer<typeof UpdateEmailInputSchema>,
+  ctx: Context,
+): Promise<UpdateEmailPayload> {
+  try {
+    const { email, id } = input;
+
+    const user = await ctx.db.query.users.findFirst({
+      where: eq(schema.users.id, id),
+    });
+
+    if (!user) {
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'User not found',
+      });
+    }
+
+    const updatedID = await ctx.db.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(schema.users)
+        .set({
+          email,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.users.id, id))
+        .returning({ updatedID: schema.users.id });
+
+      const twoFactorAuth = await tx.query.verifications.findFirst({
+        where: and(
+          eq(schema.verifications.target, user.email),
+          or(
+            eq(schema.verifications.type, '2fa'),
+            eq(schema.verifications.type, '2fa-setup'),
+          ),
+        ),
+      });
+
+      // if we have 2FA enabled or setup in progress, we need to update the
+      // verification target to the new email
+      if (twoFactorAuth) {
+        await tx
+          .update(schema.verifications)
+          .set({ target: email })
+          .where(eq(schema.verifications.id, twoFactorAuth.id));
+      }
+
+      return updated.updatedID;
+    });
+
+    return { updatedID };
+  } catch (error: unknown) {
+    logger.error(error);
+
+    throw new TRPCError({
+      cause: error,
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'An unknown error occurred',
+    });
+  }
+}
+
+export const procedure = t.procedure
+  .input(UpdateEmailInputSchema)
+  .mutation(async ({ ctx, input }) => updateEmail(input, ctx));

--- a/projects/service-user/src/handlers/update-user.test.ts
+++ b/projects/service-user/src/handlers/update-user.test.ts
@@ -23,12 +23,11 @@ test('it updates the provided user', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   const { caller } = setupTest({ db });
 
   const update = {
-    email: 'updated@test.com',
     name: 'Updated Name',
     username: 'updated_username',
   };
@@ -38,15 +37,14 @@ test('it updates the provided user', async () => {
     ...update,
   });
 
+  expect(result).toStrictEqual({ updatedID: user.id });
+
   const updatedUser = await db.query.users.findFirst({
     where: eq(schema.users.id, user.id),
   });
 
-  expect(result).toStrictEqual({ updatedID: user.id });
-
   expect(updatedUser).toStrictEqual({
     ...user,
-    email: 'updated@test.com',
     name: 'Updated Name',
     updatedAt: expect.any(Date),
     username: 'updated_username',
@@ -62,7 +60,7 @@ test('it allows partial updating', async () => {
 
   const { db } = handle;
 
-  const user = await createTestUser({ db });
+  const user = await createTestUser(db);
 
   const { caller } = setupTest({ db });
 

--- a/projects/service-user/src/handlers/update-user.ts
+++ b/projects/service-user/src/handlers/update-user.ts
@@ -8,7 +8,6 @@ import type { Context } from '../types';
 import { t } from '../t';
 
 export const UpdateUserInputSchema = z.object({
-  email: z.string().optional(),
   id: z.string(),
   name: z.string().optional(),
   username: z.string().optional(),

--- a/projects/service-user/src/handlers/verify-password.test.ts
+++ b/projects/service-user/src/handlers/verify-password.test.ts
@@ -24,7 +24,7 @@ test('it verifies a correct password', async () => {
 
   const { caller } = setupTest({ db });
 
-  const user = await createTestUser({ db, user: { password: 'password123' } });
+  const user = await createTestUser(db, { password: 'password123' });
 
   const result = await caller.verifyPassword({
     email: user.email,
@@ -41,7 +41,7 @@ test('it returns a failure payload when the password is incorrect', async () => 
 
   const { caller } = setupTest({ db });
 
-  const user = await createTestUser({ db, user: { password: 'password123' } });
+  const user = await createTestUser(db, { password: 'password123' });
 
   const result = await caller.verifyPassword({
     email: user.email,
@@ -76,7 +76,7 @@ test('it rejects a user without a password set', async () => {
 
   const { caller } = setupTest({ db });
 
-  const user = await createTestUser({ db, user: { password: null } });
+  const user = await createTestUser(db, { password: null });
 
   await expect(
     caller.verifyPassword({

--- a/projects/service-user/src/router.ts
+++ b/projects/service-user/src/router.ts
@@ -3,6 +3,7 @@ import { procedure as createPasswordResetTokenProcedure } from './handlers/creat
 import { procedure as createUserProcedure } from './handlers/create-user';
 import { procedure as getUserProcedure } from './handlers/get-user';
 import { procedure as resetPasswordProcedure } from './handlers/reset-password';
+import { procedure as updateEmailProcedure } from './handlers/update-email';
 import { procedure as updateUserProcedure } from './handlers/update-user';
 import { procedure as verifyPasswordProcedure } from './handlers/verify-password';
 import { t } from './t';
@@ -13,6 +14,7 @@ export const router = t.router({
   createUser: createUserProcedure,
   getUser: getUserProcedure,
   resetPassword: resetPasswordProcedure,
+  updateEmail: updateEmailProcedure,
   updateUser: updateUserProcedure,
   verifyPassword: verifyPasswordProcedure,
 });


### PR DESCRIPTION
## Description

- removes the ability to update `email` field via `updateUser` procedure
- adds new `updateEmail` procedure that updates 2FA + 2FA setup verification records if applicable in the same transaction

## Related Issues

closes #88

## Type of Change

<!-- Mark the appropriate option with an "x" (fill in the square brackets with an "x") -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Performed

<!-- Describe the testing you've done to verify your changes -->

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
