### PR TITLE
fix(#93): keep unverified session in store until logout processed

### DIFF
--- a/projects/app-web/app/routes/login_force-logout/route.tsx
+++ b/projects/app-web/app/routes/login_force-logout/route.tsx
@@ -109,6 +109,9 @@ async function handleConfirm(args: Route.ActionArgs) {
     );
   }
 
+  // yeet the unverified session ID from our 2FA login data incase that's how we ended up here
+  verifySession.unset('login2FA#sessionID');
+
   verifySession.unset('loginLogout#email');
   verifySession.unset('loginLogout#transactionToken');
 

--- a/projects/app-web/app/routes/verify-otp/handle-2fa.server.ts
+++ b/projects/app-web/app/routes/verify-otp/handle-2fa.server.ts
@@ -39,9 +39,8 @@ export async function handle2FA(ctx: HandleVerificationContext) {
     ctx.request.headers.get('cookie'),
   );
 
-  // clean up our session data
+  // yeet the transaction ID as we don't need it anymore
   verifySession.unset('login2FA#transactionID');
-  verifySession.unset('login2FA#sessionID');
 
   // if we need to force logout, set our session as needed then redirect
   if (isForceLogoutPayload(result.data.finishLoginWith2FA)) {
@@ -66,6 +65,10 @@ export async function handle2FA(ctx: HandleVerificationContext) {
   authSession.set('sessionID', result.data.finishLoginWith2FA.session.id);
   authSession.set('accessToken', result.data.finishLoginWith2FA.accessToken);
   authSession.set('refreshToken', result.data.finishLoginWith2FA.refreshToken);
+
+  // now that we've put our verified our session into our auth session, we can unset it from
+  // our 2FA session data
+  verifySession.unset('login2FA#sessionID');
 
   const redirectTo = ctx.submission.value.redirect ?? Routes.Dashboard;
 

--- a/projects/app-web/app/routes/verify-otp/route.test.tsx
+++ b/projects/app-web/app/routes/verify-otp/route.test.tsx
@@ -359,6 +359,9 @@ test('it handles 2FA login and redirects to the logout sessions route when a pre
   expect(verifySession.get('loginLogout#transactionToken')).toBe(
     'valid_transaction_token',
   );
+  expect(verifySession.get('login2FA#sessionID')).toBe(
+    'test_unverified_session_id',
+  );
 });
 
 test('it handles changing email and redirects to the change email route on success', async () => {


### PR DESCRIPTION
## Description

we were eagerly yeeting our unverified session ID in the 2FA login handler even if we needed to do a force logout of other sessions, so by the time we got there it'd fall over. added regression tests to cover it.

## Related Issues

#93

## Type of Change

<!-- Mark the appropriate option with an "x" (fill in the square brackets with an "x") -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Performed

<!-- Describe the testing you've done to verify your changes -->

- [x] Unit tests added/updated
