### PR TITLE
prevent refresh token loop & test improvement

### DIFF
--- a/projects/app-web/app/routes/logout/route.tsx
+++ b/projects/app-web/app/routes/logout/route.tsx
@@ -9,7 +9,7 @@ export function loader() {
 }
 
 export async function action(args: Route.ActionArgs) {
-  return logout(args.request);
+  return logout(args.request, { deleteSession: true });
 }
 
 export function ErrorBoundary() {

--- a/projects/app-web/app/utils/logout.server.test.tsx
+++ b/projects/app-web/app/utils/logout.server.test.tsx
@@ -10,6 +10,7 @@ import { Routes } from '~/types.ts';
 import { logout } from './logout.server.ts';
 
 interface TestConfig {
+  deleteSession?: boolean;
   redirectTo?: string;
   sessionID?: string;
   userID?: string;
@@ -33,7 +34,10 @@ vi.stubGlobal(
 
 function setupTest(config: TestConfig = {}) {
   const loader = async ({ request }: LoaderFunctionArgs) => {
-    return logout(request, { redirectTo: config.redirectTo });
+    return logout(request, {
+      deleteSession: config.deleteSession,
+      redirectTo: config.redirectTo,
+    });
   };
 
   const TestRoutesStub = createRoutesStub([
@@ -95,8 +99,9 @@ test('it clears the auth session', async () => {
   expect(authSession.get('accessToken')).toBeUndefined();
 });
 
-test('it deletes the session from the database', async () => {
+test('it optionally deletes the session from the database', async () => {
   setupTest({
+    deleteSession: true,
     sessionID: 'test_session_id',
     userID: 'test_user_id',
   });
@@ -116,6 +121,7 @@ test('it deletes the session from the database', async () => {
 
 test('it continues logout flow even if session deletion fails', async () => {
   setupTest({
+    deleteSession: true,
     sessionID: 'invalid_session_id',
   });
 

--- a/projects/app-web/app/utils/logout.server.ts
+++ b/projects/app-web/app/utils/logout.server.ts
@@ -8,6 +8,7 @@ import { combineHeaders } from './combine-headers.server.ts';
 import { createGQLClient } from './create-gql-client.server.ts';
 
 interface LogoutOptions {
+  deleteSession?: boolean;
   redirectTo?: string;
   responseInit?: ResponseInit;
 }
@@ -31,7 +32,7 @@ export async function logout(
 
   const sessionID = authSession.get('sessionID');
 
-  if (sessionID) {
+  if (sessionID && options.deleteSession) {
     // if we fail our server side session cleanup, ignore error's and continue.
     try {
       await client.mutation(DeleteSessionMutation, {

--- a/projects/service-api/src/schema/mutations/login-with-forced-logout.test.ts
+++ b/projects/service-api/src/schema/mutations/login-with-forced-logout.test.ts
@@ -138,6 +138,7 @@ test('it removes all previous sessions when a user is logged in', async () => {
   });
 
   expect(sessions).toHaveLength(1);
+  expect(sessions[0].id).toBe(session.id);
 });
 
 test('it returns an error if the transaction token is invalid', async () => {


### PR DESCRIPTION
## Description

- prevent a refresh token loop after we force logout due to deleting our session on logout -> refresh fail -> delete -> refresh fail....etc.

## Related Issues

#93

## Type of Change

<!-- Mark the appropriate option with an "x" (fill in the square brackets with an "x") -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Performed

<!-- Describe the testing you've done to verify your changes -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
