### PR TITLE
fixes

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -7,7 +7,7 @@ export default {
   'projects/**/*.{ts,tsx}': [
     'yarn codegen:styles',
     (files) => `yarn nx affected --target=typecheck --files=${files.join(',')}`,
-    (files) => `yarn test run ${files.join(' ')}`,
+    'yarn test run --changed',
   ],
   'projects/**/*.{js,ts,jsx,tsx,json}': (files) => [
     `yarn format --files ${files.join(',')}`,

--- a/projects/app-web/app/routes/account_verify-2fa/route.tsx
+++ b/projects/app-web/app/routes/account_verify-2fa/route.tsx
@@ -250,6 +250,7 @@ export function AccountVerify2FARoute(props: Route.ComponentProps) {
                 ...getInputProps(fields.code, { type: 'text' }),
                 autoComplete: 'one-time-code',
                 autoFocus: true,
+                mode: 'numeric',
               }}
             />
             <input {...getInputProps(fields.target, { type: 'hidden' })} />

--- a/projects/app-web/app/routes/avatar/route.tsx
+++ b/projects/app-web/app/routes/avatar/route.tsx
@@ -1,11 +1,13 @@
 import { redirect } from 'react-router';
 import { classes } from '@vers/data';
 import { Heading, Text } from '@vers/design-system';
+import invariant from 'tiny-invariant';
 import { ContentContainer } from '~/components/content-container';
 import { RouteErrorBoundary } from '~/components/route-error-boundary';
 import { GetAvatarsQuery } from '~/data/queries/get-avatars';
 import { resolveClassFromGQLEnum } from '~/data/utils/resolve-class-from-gql-enum.ts';
 import { Routes } from '~/types';
+import { handleGQLError } from '~/utils/handle-gql-error';
 import { requireAuth } from '~/utils/require-auth.server';
 import { withErrorHandling } from '~/utils/with-error-handling';
 import type { Route } from './+types/route';
@@ -20,11 +22,19 @@ export const meta: Route.MetaFunction = () => [
 export const loader = withErrorHandling(async (args: Route.LoaderArgs) => {
   await requireAuth(args.request);
 
-  const { data } = await args.context.client.query(GetAvatarsQuery, {
+  const result = await args.context.client.query(GetAvatarsQuery, {
     input: {},
   });
 
-  const avatar = data?.getAvatars[0];
+  if (result.error) {
+    handleGQLError(result.error);
+
+    throw result.error;
+  }
+
+  invariant(result.data, 'if no error, there must be data');
+
+  const avatar = result.data.getAvatars[0];
 
   if (!avatar) {
     return redirect(Routes.AvatarCreate);

--- a/projects/app-web/app/routes/nexus/route.test.tsx
+++ b/projects/app-web/app/routes/nexus/route.test.tsx
@@ -15,7 +15,6 @@ interface TestConfig {
   isAuthed: boolean;
   user?: {
     id?: string;
-    name?: string;
   };
 }
 
@@ -67,7 +66,7 @@ test('it redirects to the login route when not authenticated', async () => {
 test('it renders the nexus when authenticated and a user has an avatar', async () => {
   db.avatar.create({ userID: 'user_id' });
 
-  setupTest({ isAuthed: true, user: { id: 'user_id', name: 'Test User' } });
+  setupTest({ isAuthed: true, user: { id: 'user_id' } });
 
   const nexus = await screen.findByText('Nexus');
 
@@ -75,10 +74,7 @@ test('it renders the nexus when authenticated and a user has an avatar', async (
 });
 
 test('it renders a call to action when a user does not have an avatar', async () => {
-  const { user } = setupTest({
-    isAuthed: true,
-    user: { id: 'user_id', name: 'Test User' },
-  });
+  const { user } = setupTest({ isAuthed: true, user: { id: 'user_id' } });
 
   const callToAction = await screen.findByText('Awaken your Avatar');
 

--- a/projects/app-web/app/routes/verify-otp/route.tsx
+++ b/projects/app-web/app/routes/verify-otp/route.tsx
@@ -188,6 +188,20 @@ const INSTRUCTION_BY_TYPE: Record<VerificationType, string> = {
     'To enable two-factor authentication, please enter your six digit code from your authenticator app',
 };
 
+const OTP_INPUT_MODE_BY_TYPE: Record<
+  VerificationType,
+  'alphanumeric' | 'numeric'
+> = {
+  [VerificationType.ChangeEmail]: 'numeric',
+  [VerificationType.ChangeEmailConfirmation]: 'alphanumeric',
+  [VerificationType.ChangePassword]: 'numeric',
+  [VerificationType.Onboarding]: 'alphanumeric',
+  [VerificationType.ResetPassword]: 'alphanumeric',
+  [VerificationType.TwoFactorAuth]: 'numeric',
+  [VerificationType.TwoFactorAuthDisable]: 'numeric',
+  [VerificationType.TwoFactorAuthSetup]: 'numeric',
+};
+
 const pageInfo = css({
   marginBottom: '8',
   textAlign: 'center',
@@ -240,6 +254,8 @@ export function VerifyOTPRoute(props: Route.ComponentProps) {
     ? INSTRUCTION_BY_TYPE[type]
     : 'Please enter your verification code';
 
+  const otpInputMode = type ? OTP_INPUT_MODE_BY_TYPE[type] : 'numeric';
+
   return (
     <>
       <section className={pageInfo}>
@@ -258,6 +274,7 @@ export function VerifyOTPRoute(props: Route.ComponentProps) {
             ...getInputProps(fields[QueryParam.Code], { type: 'text' }),
             autoComplete: 'one-time-code',
             autoFocus: true,
+            mode: otpInputMode,
           }}
         />
         <input

--- a/projects/app-web/app/utils/get-login-path-with-redirect.server.test.ts
+++ b/projects/app-web/app/utils/get-login-path-with-redirect.server.test.ts
@@ -8,3 +8,11 @@ test('it returns the login path with the redirect query param', () => {
 
   expect(result).toBe('/login?redirect=%2Fquery%3Ffoo%3Dbar');
 });
+
+test('it strips the .data from the path', () => {
+  const request = new Request('http://localhost:3000/query.data?foo=bar', {});
+
+  const result = getLoginPathWithRedirect(request);
+
+  expect(result).toBe('/login?redirect=%2Fquery%3Ffoo%3Dbar');
+});

--- a/projects/app-web/app/utils/get-login-path-with-redirect.server.ts
+++ b/projects/app-web/app/utils/get-login-path-with-redirect.server.ts
@@ -5,7 +5,7 @@ import { Routes } from '~/types';
  */
 export function getLoginPathWithRedirect(request: Request) {
   const url = new URL(request.url);
-  const loginRedirect = `${url.pathname}?${url.searchParams.toString()}`;
+  const loginRedirect = `${url.pathname.replace('.data', '')}?${url.searchParams.toString()}`;
   const searchParams = new URLSearchParams({ redirect: loginRedirect });
   const loginWithRedirectPath = `${Routes.Login}?${searchParams.toString()}`;
 

--- a/projects/lib-design-system/src/components/otp-field/otp-field.tsx
+++ b/projects/lib-design-system/src/components/otp-field/otp-field.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { Field } from '@base-ui-components/react/field';
 import { css, cx } from '@vers/styled-system/css';
-import { REGEXP_ONLY_DIGITS_AND_CHARS } from 'input-otp';
+import { REGEXP_ONLY_DIGITS, REGEXP_ONLY_DIGITS_AND_CHARS } from 'input-otp';
 import { InputOTP } from './input-otp.tsx';
 
 interface Props {
   className?: string;
   errors: Array<string>;
-  inputProps: React.ComponentProps<typeof Field.Control>;
+  inputProps: React.ComponentProps<typeof Field.Control> & {
+    mode?: 'alphanumeric' | 'numeric';
+  };
 }
 
 const container = css({
@@ -49,6 +51,14 @@ export function OTPField(props: Props) {
             controlProps.onChange?.(event);
           };
 
+          const pattern =
+            props.inputProps.mode === 'alphanumeric'
+              ? REGEXP_ONLY_DIGITS_AND_CHARS
+              : REGEXP_ONLY_DIGITS;
+
+          const inputMode =
+            props.inputProps.mode === 'alphanumeric' ? 'text' : 'numeric';
+
           return (
             <InputOTP
               {...controlProps}
@@ -56,8 +66,9 @@ export function OTPField(props: Props) {
               autoComplete="off"
               autoCorrect="off"
               data-testid="otp-input"
+              inputMode={inputMode}
               maxLength={6}
-              pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+              pattern={pattern}
               spellCheck={false}
               value={controlProps.value as string}
               onChange={onChange}

--- a/projects/service-session/src/handlers/get-sessions.test.ts
+++ b/projects/service-session/src/handlers/get-sessions.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 import { createId } from '@paralleldrive/cuid2';
 import * as schema from '@vers/postgres-schema';
 import { createTestDB, createTestUser } from '@vers/service-test-utils';
+import { eq } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { router } from '../router';
 import { t } from '../t';
@@ -96,4 +97,38 @@ test('it returns an empty array if the user has no sessions', async () => {
 
   expect(result).toHaveLength(0);
   expect(result).toStrictEqual([]);
+});
+
+test('it deletes expired sessions and doesnt return them', async () => {
+  await using handle = await createTestDB();
+
+  const { db } = handle;
+
+  const { caller, user } = await setupTest({ db });
+
+  const now = new Date();
+  const sessionID = createId();
+
+  await db.insert(schema.sessions).values({
+    createdAt: now,
+    expiresAt: new Date(now.getTime() - 1000),
+    id: sessionID,
+    ipAddress: '127.0.0.1',
+    refreshToken: 'refresh-token-1',
+    updatedAt: now,
+    userID: user.id,
+    verified: false,
+  });
+
+  const result = await caller.getSessions({
+    userID: user.id,
+  });
+
+  expect(result).toHaveLength(0);
+
+  const session = await db.query.sessions.findFirst({
+    where: eq(schema.sessions.id, sessionID),
+  });
+
+  expect(session).toBeUndefined();
 });


### PR DESCRIPTION
## Description

- handle gql errors when fetching avatars so that 401 redirects are correctly thrown
- remove `.data` from login redirect urls
- contextually use numeric/alphanumeric keyboards for OTP input
- yeet expired sessions when retrieving them and don't return them

## Related Issues

* closes #123 
* closes #113
* closes #118 
* closes #112

## Type of Change

<!-- Mark the appropriate option with an "x" (fill in the square brackets with an "x") -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Performed

<!-- Describe the testing you've done to verify your changes -->

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
